### PR TITLE
regression 4101: fix test

### DIFF
--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -144,7 +144,7 @@ static void xtest_tee_test_4101(ADBG_Case_t *c)
 		return;
 
 	rv = C_Finalize(NULL);
-	ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK);
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		return;
 
 	rv = C_Initialize(NULL);


### PR DESCRIPTION
Fix typo that bypasses half of test 4101. Fix reported during formal
P-R review.

Reported-by: Jens Wiklander <jens.wiklander@linaro.org>
Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>