### PR TITLE
various cleanup and changes from SKS code review

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -22,7 +22,7 @@ LOCAL_MODULE := xtest
 LOCAL_SHARED_LIBRARIES := libteec
 
 ifeq ($(CFG_SECURE_KEY_SERVICES),y)
-LOCAL_SHARED_LIBRARIES += liboptee_cryptoki
+LOCAL_SHARED_LIBRARIES += libsks
 endif
 
 srcs := regression_1000.c

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -51,6 +51,10 @@ if (CFG_SECURE_DATA_PATH)
 	list (APPEND SRC sdp_basic.c)
 endif()
 
+if (CFG_SECURE_KEY_SERVICES)
+	list (APPEND SRC regression_4100.c)
+endif()
+
 ################################################################################
 # Built binary
 ################################################################################
@@ -58,10 +62,6 @@ add_executable (${PROJECT_NAME} ${SRC})
 
 target_compile_options (${PROJECT_NAME}
 	PRIVATE -include conf.h
-)
-
-set_target_properties(${PROJECT_NAME}
-	PROPERTIES COMPILE_FLAGS "-DCFG_SECURE_KEY_SERVICES"
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/host/xtest/CMakeLists.txt
+++ b/host/xtest/CMakeLists.txt
@@ -24,7 +24,6 @@ set (SRC
 	benchmark_2000.c
 	regression_1000.c
 	regression_4000.c
-	regression_4100.c
 	regression_5000.c
 	regression_6000.c
 	regression_7000.c
@@ -76,7 +75,7 @@ target_link_libraries (${PROJECT_NAME}
 	PRIVATE xtest-ta-headers
 	PRIVATE teec
 	PRIVATE m
-	PRIVATE optee_cryptoki
+	PRIVATE sks
 )
 
 ################################################################################

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -59,7 +59,6 @@ ifeq ($(CFG_SECURE_DATA_PATH),y)
 srcs += sdp_basic.c
 endif
 
-CFG_SECURE_KEY_SERVICES ?= y
 ifeq ($(CFG_SECURE_KEY_SERVICES),y)
 srcs += regression_4100.c
 OPTEE_SKS_HEADERS ?= ../../../optee_client/libsks/include

--- a/host/xtest/Makefile
+++ b/host/xtest/Makefile
@@ -64,7 +64,7 @@ srcs += regression_4100.c
 OPTEE_SKS_HEADERS ?= ../../../optee_client/libsks/include
 CFLAGS += -DCFG_SECURE_KEY_SERVICES
 CFLAGS += -I$(OPTEE_SKS_HEADERS)
-LDFLAGS += -L$(OPTEE_CLIENT_EXPORT)/lib -loptee_cryptoki
+LDFLAGS += -L$(OPTEE_CLIENT_EXPORT)/lib -lsks
 endif
 
 ifdef CFG_GP_PACKAGE_PATH

--- a/host/xtest/regression_4100.c
+++ b/host/xtest/regression_4100.c
@@ -984,17 +984,24 @@ static void xtest_tee_test_4108(ADBG_Case_t *c)
 
 	for (n = 0; n < ARRAY_SIZE(cktest_allowed_valid); n++) {
 
+		Do_ADBG_BeginSubCase(c, "valid usage #%u", n);
+
 		rv = cipher_init_final(c, session,
 					cktest_allowed_valid[n].attr_key,
 					cktest_allowed_valid[n].attr_count,
 					cktest_allowed_valid[n].mechanism,
 					TEE_MODE_ENCRYPT,
 					CKR_OK);
+
+		ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK);
+		Do_ADBG_EndSubCase(c, NULL);
 		if (rv)
 			goto bail;
+
 	}
 
 	for (n = 0; n < ARRAY_SIZE(cktest_allowed_invalid); n++) {
+		Do_ADBG_BeginSubCase(c, "invalid usage #%u", n);
 
 		rv = cipher_init_final(c, session,
 					cktest_allowed_invalid[n].attr_key,
@@ -1002,8 +1009,12 @@ static void xtest_tee_test_4108(ADBG_Case_t *c)
 					cktest_allowed_invalid[n].mechanism,
 					TEE_MODE_ENCRYPT,
 					CKR_KEY_FUNCTION_NOT_PERMITTED);
+
+		ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK);
+		Do_ADBG_EndSubCase(c, NULL);
 		if (rv)
 			goto bail;
+
 	}
 
 bail:
@@ -1036,7 +1047,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_cts_mechanism,
 				TEE_MODE_ENCRYPT,
 				CKR_OK);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	rv = cipher_init_final(c, session,
@@ -1045,7 +1056,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_cts_mechanism,
 				TEE_MODE_DECRYPT,
 				CKR_KEY_FUNCTION_NOT_PERMITTED);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	/* Decrypt only AES CTR key */
@@ -1055,7 +1066,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_ctr_mechanism,
 				TEE_MODE_ENCRYPT,
 				CKR_KEY_FUNCTION_NOT_PERMITTED);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	rv = cipher_init_final(c, session,
@@ -1064,7 +1075,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_ctr_mechanism,
 				TEE_MODE_ENCRYPT,
 				CKR_KEY_FUNCTION_NOT_PERMITTED);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	/* Encrypt only AES GCM key */
@@ -1074,7 +1085,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_gcm_mechanism,
 				TEE_MODE_ENCRYPT,
 				CKR_OK);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	rv = cipher_init_final(c, session,
@@ -1083,7 +1094,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_gcm_mechanism,
 				TEE_MODE_DECRYPT,
 				CKR_KEY_FUNCTION_NOT_PERMITTED);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	/* Decrypt only AES CCM key */
@@ -1093,7 +1104,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_ccm_mechanism,
 				TEE_MODE_DECRYPT,
 				CKR_OK);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 	rv = cipher_init_final(c, session,
@@ -1102,7 +1113,7 @@ static void xtest_tee_test_4109(ADBG_Case_t *c)
 				&cktest_aes_ccm_mechanism,
 				TEE_MODE_ENCRYPT,
 				CKR_KEY_FUNCTION_NOT_PERMITTED);
-	if (rv)
+	if (!ADBG_EXPECT_COMPARE_UNSIGNED(c, rv, ==, CKR_OK))
 		goto bail;
 
 bail:


### PR DESCRIPTION
Clean make scripts.
liboptee_cryptoki is renamed libsks.
Add adbg traces to locate failing tests.